### PR TITLE
Limit number of concurrent requests in build duration logger example

### DIFF
--- a/samples/build-duration-logger/index.html
+++ b/samples/build-duration-logger/index.html
@@ -13,8 +13,8 @@
 
     class BuildDurationProcessor {
 
-        constructor(gradleEnterpriseServer, maxConcurrentBuildsToProcess = 6) {
-            this.gradleEnterpriseServer = gradleEnterpriseServer;
+        constructor(gradleEnterpriseServerUrl, maxConcurrentBuildsToProcess = 6) {
+            this.gradleEnterpriseServerUrl = gradleEnterpriseServerUrl;
             this.pendingBuildIds = [];
             this.numBuildsInProcess = 0;
             this.maxConcurrentBuildsToProcess = maxConcurrentBuildsToProcess;
@@ -33,7 +33,7 @@
         }
 
         createBuildDurationEventStreamUrl(buildId) {
-            return `${this.gradleEnterpriseServer}/build-export/v1/build/${buildId}/events?eventTypes=BuildStarted,BuildFinished`;
+            return `${this.gradleEnterpriseServerUrl}/build-export/v1/build/${buildId}/events?eventTypes=BuildStarted,BuildFinished`;
         }
 
         processBuild(buildId) {

--- a/samples/build-duration-logger/index.html
+++ b/samples/build-duration-logger/index.html
@@ -26,7 +26,6 @@
         processPendingBuilds() {
             if (this.pendingBuildIds.length > 0 && this.numBuildsInProcess < this.maxConcurrentBuildsToProcess) {
                 this.processBuild(this.pendingBuildIds.shift());
-                setTimeout(() => this.processPendingBuilds(), 0);
             }
         }
 
@@ -55,6 +54,7 @@
 
                     console.log(`Build ${buildId} completed in ${endTime - startTime}ms`);
                     this.numBuildsInProcess--;
+                    setTimeout(() => this.processPendingBuilds(), 0);
                 }
             });
         }

--- a/samples/build-duration-logger/index.html
+++ b/samples/build-duration-logger/index.html
@@ -7,42 +7,42 @@
 
 <body>
 <script>
-    const gradleEnterpriseServer = 'https://gradle.my-company.com'; // replace with your Gradle Enterprise base url
-    const buildStreamUrl = `${gradleEnterpriseServer}/build-export/v1/builds/since/now?stream`;
+    const gradleEnterpriseServerUrl = 'https://gradle.my-company.com'; // replace with your Gradle Enterprise base url
+    const buildStreamUrl = `${gradleEnterpriseServerUrl}/build-export/v1/builds/since/now?stream`;
     const buildStream = new EventSource(buildStreamUrl);
 
-    class BuildProcessor {
+    class BuildDurationProcessor {
 
-        constructor(gradleEnterpriseServer, maxConcurrentBuildsToProcess) {
+        constructor(gradleEnterpriseServer, maxConcurrentBuildsToProcess = 6) {
             this.gradleEnterpriseServer = gradleEnterpriseServer;
-            this.buildIds = [];
+            this.pendingBuildIds = [];
             this.numBuildsInProcess = 0;
             this.maxConcurrentBuildsToProcess = maxConcurrentBuildsToProcess;
         }
 
         enqueue(buildId) {
-            this.buildIds.push(buildId);
-            this.processQueuedBuilds();
+            this.pendingBuildIds.push(buildId);
+            this.processPendingBuilds();
         }
 
-        processQueuedBuilds() {
-            if (this.buildIds.length > 0 && this.numBuildsInProcess < this.maxConcurrentBuildsToProcess) {
-                this.processBuild(this.buildIds.shift());
-                setTimeout(this.processQueuedBuilds.bind(this), 0);
+        processPendingBuilds() {
+            if (this.pendingBuildIds.length > 0 && this.numBuildsInProcess < this.maxConcurrentBuildsToProcess) {
+                this.processBuild(this.pendingBuildIds.shift());
+                setTimeout(() => this.processPendingBuilds(), 0);
             }
         }
 
-        buildEventStreamUrl(buildId) {
+        createBuildDurationEventStreamUrl(buildId) {
             return `${this.gradleEnterpriseServer}/build-export/v1/build/${buildId}/events?eventTypes=BuildStarted,BuildFinished`;
         }
 
         processBuild(buildId) {
             this.numBuildsInProcess++;
-            const buildEventStream = new EventSource(this.buildEventStreamUrl(buildId));
+            const buildDurationEventStream = new EventSource(this.createBuildDurationEventStreamUrl(buildId));
 
             let startTime;
 
-            buildEventStream.addEventListener('BuildEvent', event => {
+            buildDurationEventStream.addEventListener('BuildEvent', event => {
                 const buildEventPayload = JSON.parse(event.data);
                 const eventType = buildEventPayload.type.eventType;
 
@@ -58,15 +58,14 @@
         }
     };
 
-    const maxConcurrentBuildsToProcess = 6;
-    const buildProcessor = new BuildProcessor(gradleEnterpriseServer, maxConcurrentBuildsToProcess);
+    const buildDurationProcessor = new BuildDurationProcessor(gradleEnterpriseServerUrl);
 
     buildStream.onopen = event => console.log(`Build stream '${buildStreamUrl}' open`);
     buildStream.onerror = event => console.error('Build stream error', event);
     buildStream.addEventListener('Build', event => {
         const buildPayload = JSON.parse(event.data);
 
-        buildProcessor.enqueue(buildPayload.buildId);
+        buildDurationProcessor.enqueue(buildPayload.buildId);
     });
 </script>
 </body>

--- a/samples/build-duration-logger/index.html
+++ b/samples/build-duration-logger/index.html
@@ -7,9 +7,7 @@
 
 <body>
 <script>
-    const gradleEnterpriseServerUrl = 'https://gradle.my-company.com'; // replace with your Gradle Enterprise base url
-    const buildStreamUrl = `${gradleEnterpriseServerUrl}/build-export/v1/builds/since/now?stream`;
-    const buildStream = new EventSource(buildStreamUrl);
+    const GRADLE_ENTERPRISE_SERVER_URL = 'https://gradle.my-company.com'; // replace with your Gradle Enterprise base url
 
     class BuildDurationProcessor {
 
@@ -30,6 +28,10 @@
                 this.processBuild(this.pendingBuildIds.shift());
                 setTimeout(() => this.processPendingBuilds(), 0);
             }
+        }
+
+        createBuildStreamUrl(startTime = 'now') {
+            return `${this.gradleEnterpriseServerUrl}/build-export/v1/builds/since/${startTime}?stream`;
         }
 
         createBuildDurationEventStreamUrl(buildId) {
@@ -58,7 +60,9 @@
         }
     };
 
-    const buildDurationProcessor = new BuildDurationProcessor(gradleEnterpriseServerUrl);
+    const buildDurationProcessor = new BuildDurationProcessor(GRADLE_ENTERPRISE_SERVER_URL);
+    const buildStreamUrl = buildDurationProcessor.createBuildStreamUrl();
+    const buildStream = new EventSource(buildStreamUrl);
 
     buildStream.onopen = event => console.log(`Build stream '${buildStreamUrl}' open`);
     buildStream.onerror = event => console.error('Build stream error', event);

--- a/samples/build-duration-logger/index.html
+++ b/samples/build-duration-logger/index.html
@@ -53,6 +53,8 @@
                     const endTime = buildEventPayload.timestamp;
 
                     console.log(`Build ${buildId} completed in ${endTime - startTime}ms`);
+                    buildDurationEventStream.close();
+
                     this.numBuildsInProcess--;
                     setTimeout(() => this.processPendingBuilds(), 0);
                 }

--- a/samples/build-duration-logger/index.html
+++ b/samples/build-duration-logger/index.html
@@ -10,28 +10,63 @@
     const gradleEnterpriseServer = 'https://gradle.my-company.com'; // replace with your Gradle Enterprise base url
     const buildStreamUrl = `${gradleEnterpriseServer}/build-export/v1/builds/since/now?stream`;
     const buildStream = new EventSource(buildStreamUrl);
-    const buildEventStreamUrl = buildId => `${gradleEnterpriseServer}/build-export/v1/build/${buildId}/events?eventTypes=BuildStarted,BuildFinished`;
+
+    class BuildProcessor {
+
+        constructor(gradleEnterpriseServer, maxConcurrentBuildsToProcess) {
+            this.gradleEnterpriseServer = gradleEnterpriseServer;
+            this.buildIds = [];
+            this.numBuildsInProcess = 0;
+            this.maxConcurrentBuildsToProcess = maxConcurrentBuildsToProcess;
+        }
+
+        enqueue(buildId) {
+            this.buildIds.push(buildId);
+            this.processQueuedBuilds();
+        }
+
+        processQueuedBuilds() {
+            if (this.buildIds.length > 0 && this.numBuildsInProcess < this.maxConcurrentBuildsToProcess) {
+                this.processBuild(this.buildIds.shift());
+                setTimeout(this.processQueuedBuilds.bind(this), 0);
+            }
+        }
+
+        buildEventStreamUrl(buildId) {
+            return `${this.gradleEnterpriseServer}/build-export/v1/build/${buildId}/events?eventTypes=BuildStarted,BuildFinished`;
+        }
+
+        processBuild(buildId) {
+            this.numBuildsInProcess++;
+            const buildEventStream = new EventSource(this.buildEventStreamUrl(buildId));
+
+            let startTime;
+
+            buildEventStream.addEventListener('BuildEvent', event => {
+                const buildEventPayload = JSON.parse(event.data);
+                const eventType = buildEventPayload.type.eventType;
+
+                if (eventType == 'BuildStarted') {
+                    startTime = buildEventPayload.timestamp;
+                } else if (eventType == 'BuildFinished') {
+                    const endTime = buildEventPayload.timestamp;
+
+                    console.log(`Build ${buildId} completed in ${endTime - startTime}ms`);
+                    this.numBuildsInProcess--;
+                }
+            });
+        }
+    };
+
+    const maxConcurrentBuildsToProcess = 6;
+    const buildProcessor = new BuildProcessor(gradleEnterpriseServer, maxConcurrentBuildsToProcess);
 
     buildStream.onopen = event => console.log(`Build stream '${buildStreamUrl}' open`);
     buildStream.onerror = event => console.error('Build stream error', event);
     buildStream.addEventListener('Build', event => {
         const buildPayload = JSON.parse(event.data);
-        const buildEventStream = new EventSource(buildEventStreamUrl(buildPayload.buildId));
 
-        let startTime;
-
-        buildEventStream.addEventListener('BuildEvent', event => {
-            const buildEventPayload = JSON.parse(event.data);
-            const eventType = buildEventPayload.type.eventType;
-
-            if (eventType == 'BuildStarted') {
-                startTime = buildEventPayload.timestamp;
-            } else if (eventType == 'BuildFinished') {
-                const endTime = buildEventPayload.timestamp;
-
-                console.log(`Build ${buildPayload.buildId} completed in ${endTime - startTime}ms`);
-            }
-        });
+        buildProcessor.enqueue(buildPayload.buildId);
     });
 </script>
 </body>


### PR DESCRIPTION
Avoid overloading the server with many concurrent requests to fetch the individual build start and end events.